### PR TITLE
Fix OG image meta tag URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
 <meta property="og:url" content="https://www.integrityevsolutions.com/" />
 <meta property="og:title" content="Integrity EV Solutions | Atlanta EV Charger Installation" />
 <meta property="og:description" content="Professional, inclusive, and committed to excellence—book your free EV charger installation estimate today!" />
-<meta property="og:image" content="charger-illustration.png" />
+<meta property="og:image" content="https://www.integrityevsolutions.com/charger-illustration.png" />
 
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:url" content="https://www.integrityevsolutions.com/" />
 <meta name="twitter:title" content="Integrity EV Solutions | Atlanta EV Charger Installation" />
 <meta name="twitter:description" content="Family-owned, licensed, & insured—your go-to experts for home and business EV charging in Atlanta." />
-<meta name="twitter:image" content="charger-illustration.png" />
+<meta name="twitter:image" content="https://www.integrityevsolutions.com/charger-illustration.png" />
 
 <!-- Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRSTDB8HTH"></script>


### PR DESCRIPTION
## Summary
- use absolute URLs for `og:image` and `twitter:image`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880f0ee6d2c8331b9d08730ec333c72