### PR TITLE
Add Formsubmit contact form and conversion tracking page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Contact Us | Integrity EV Solutions</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    .contact-form-container {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 1rem;
+    }
+    .contact-form {
+      display: grid;
+      gap: 1rem;
+    }
+    .contact-form label {
+      font-weight: 600;
+    }
+    .contact-form input,
+    .contact-form textarea {
+      width: 100%;
+      padding: 0.75rem;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 1rem;
+    }
+    .contact-form button {
+      padding: 0.75rem;
+      background-color: var(--color-primary, #005F2E);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 1rem;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .contact-form button:hover {
+      filter: brightness(1.1);
+    }
+  </style>
+</head>
+<body>
+  <main class="contact-form-container">
+    <h1>Contact Us</h1>
+    <form class="contact-form" action="https://formsubmit.co/integrityevsolutions@gmail.com" method="POST">
+      <input type="hidden" name="_next" value="https://www.integrityevsolutions.com/thank-you.html" />
+      <input type="hidden" name="_captcha" value="false" />
+      <label for="name">Name</label>
+      <input type="text" id="name" name="name" required />
+
+      <label for="email">Email</label>
+      <input type="email" id="email" name="email" required />
+
+      <label for="phone">Phone</label>
+      <input type="tel" id="phone" name="phone" required />
+
+      <label for="message">Message</label>
+      <textarea id="message" name="message" rows="5" required></textarea>
+
+      <button type="submit">Send Message</button>
+    </form>
+  </main>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,16 @@
     <changefreq>weekly</changefreq>
     <priority>1.00</priority>
   </url>
+  <url>
+    <loc>https://www.integrityevsolutions.com/contact.html</loc>
+    <lastmod>2025-07-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.80</priority>
+  </url>
+  <url>
+    <loc>https://www.integrityevsolutions.com/thank-you.html</loc>
+    <lastmod>2025-07-30</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.40</priority>
+  </url>
 </urlset>

--- a/thank-you.html
+++ b/thank-you.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Thank You | Integrity EV Solutions</title>
+  <link rel="stylesheet" href="style.css" />
+  <style>
+    .thank-you-container {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 2rem 1rem;
+      text-align: center;
+    }
+  </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17428301350"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'AW-17428301350');
+    gtag('event', 'conversion', {
+      'send_to': 'AW-17428301350/ArNACM-3z4MbEKaMu_ZA',
+      'value': 1.0,
+      'currency': 'USD'
+    });
+  </script>
+</head>
+<body>
+  <main class="thank-you-container">
+    <h1>Thank You!</h1>
+    <p>Your message has been sent. We will be in touch soon.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone contact form using Formsubmit that collects name, email, phone and message
- create thank-you page with gtag conversion snippet and simple styling
- include new pages in sitemap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e9241064833185a086d58415991e