### PR TITLE
Trigger conversions on interaction only

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,23 +14,6 @@
 
   gtag('config', 'AW-17428301350');
 </script>
-
-<!-- Event snippet for phone conversion -->
-<script>
-  gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
-    'phone_conversion_number': '470-262-2660'
-  });
-</script>
-
-<!-- Event snippet for Submit lead form conversion page -->
-<script>
-  gtag('event', 'conversion', {
-      'send_to': 'AW-17428301350/ArNACM-3z4MbEKaMu_ZA',
-      'value': 1.0,
-      'currency': 'USD'
-  });
-</script>
-  
 <title>Integrity EV Solutions</title>
 
   <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
@@ -80,7 +63,7 @@
       </a>
       <span>
         <a href="#hero" class="name">Integrity EV Solutions</a><br>
-        <span class="tagline">Family-Owned • Northern Georgia &amp; Greater Atlanta • <a href="tel:4702622660">470-262-2660</a></span>
+          <span class="tagline">Family-Owned • Northern Georgia &amp; Greater Atlanta • <a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></span>
       </span>
     </div>
     <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu">
@@ -369,7 +352,7 @@
       <div class="contact-card">
         <div class="icon">📞</div>
         <h3>Call or Text</h3>
-        <p><a href="tel:4702622660">470-262-2660</a></p>
+          <p><a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></p>
         <p>Mon–Fri: 8 am–6 pm</p>
       </div>
       <div class="contact-card">
@@ -391,7 +374,7 @@
 <!-- FOOTER -->
 <footer class="site-footer">
   <div class="footer-container">
-    <div class="footer-phone"><a href="tel:4702622660">📞 470-262-2660</a></div>
+      <div class="footer-phone"><a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">📞 470-262-2660</a></div>
     <nav class="footer-nav" aria-label="Footer Navigation">
       <a href="#hero">Home</a>
       <a href="#core-values">Core Values</a>


### PR DESCRIPTION
## Summary
- Fire Google Ads phone conversion only when phone number links are clicked.
- Remove lead conversion from the main page so it triggers only on the thank-you page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f3e3b0bc8331af872a71ab84360e