### PR TITLE
Enhance hero messaging with prominent estimate CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
         <img src="logo.png" alt="Integrity EV Solutions logo" />
       </a>
       <span>
-        <a href="#hero" class="name">Integrity EV Solutions</a><br>
+      <a href="#hero" class="name">Integrity EV Solutions</a><br>
           <span class="tagline">Family-Owned • Northern Georgia &amp; Greater Atlanta • <a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></span>
       </span>
     </div>
@@ -76,7 +76,7 @@
       <a href="#process">Process</a>
       <a href="#testimonials">Testimonials</a>
       <a href="#faqs">FAQs</a>
-      <a href="#receive" class="cta">Get a Quote</a>
+      <a href="#receive" class="cta">Get My Free Estimate</a>
       <a href="#contact">Contact</a>
     </div>
   </div>
@@ -86,9 +86,9 @@
 <section id="hero" class="full-bleed hidden">
   <div class="inner-wrap">
     <div class="hero-content">
-      <h1>Powering Your Journey to a Greener Future</h1>
-      <p class="sub">Family-Owned • Northern Georgia &amp; Greater Atlanta</p>
-      <a href="#receive" class="cta-hero">Get a Free Estimate</a>
+      <h1>EV Charger Installation — Fast, Certified &amp; Hassle-Free</h1>
+      <p class="sub">Georgia homeowners trust us for rebate-ready EV charger installs, done right the first time.</p>
+      <a href="#receive" class="cta-hero">Get My Free Estimate</a>
     </div>
   </div>
 </section>
@@ -383,7 +383,7 @@
       <a href="#process">Process</a>
       <a href="#testimonials">Testimonials</a>
       <a href="#faqs">FAQs</a>
-      <a href="#receive">Get a Quote</a>
+      <a href="#receive">Get My Free Estimate</a>
       <a href="#contact">Contact</a>
     </nav>
     <div class="footer-copy">© 2025 Integrity EV Solutions. All rights reserved.</div>

--- a/style.css
+++ b/style.css
@@ -89,10 +89,11 @@ body{
 .menu a:hover{color:var(--color-accent);}
 .menu a.cta{
   background:var(--color-accent);
-  color:var(--color-primary)!important;
-  padding:.6rem 1.05rem;
+  color:var(--black)!important;
+  padding:.8rem 1.35rem;
   border-radius:4px;
   font-weight:700;
+  font-size:1rem;
   box-shadow:0 2px 4px rgba(0,0,0,.15);
 }
 .menu a.cta:hover{filter:brightness(1.07);}
@@ -133,7 +134,7 @@ body{
     max-height:500px;
   }
   .menu a{padding:.45rem 0;width:100%;}
-  .menu a.cta{width:auto;align-self:stretch;text-align:center;margin-top:.25rem;}
+  .menu a.cta{width:auto;align-self:stretch;text-align:center;margin-top:.25rem;font-size:1.1rem;}
 }
 
 /******** GENERIC LAYOUT ********/
@@ -182,10 +183,11 @@ section.full-bleed > .inner-wrap{max-width:var(--wrap-max);}
 }
 #hero .cta-hero{
   background:var(--color-accent);
-  color:var(--color-primary);
-  padding:1rem 2rem;
+  color:var(--black);
+  padding:1.15rem 2.5rem;
   border-radius:4px;
   font-weight:700;
+  font-size:1.15rem;
   text-decoration:none;
   display:inline-block;
   box-shadow:0 4px 12px rgba(0,0,0,.25);

--- a/thank-you.html
+++ b/thank-you.html
@@ -61,7 +61,7 @@
         <a href="/#process">Process</a>
         <a href="/#testimonials">Testimonials</a>
         <a href="/#faqs">FAQs</a>
-        <a href="/#receive" class="cta">Get a Quote</a>
+        <a href="/#receive" class="cta">Get My Free Estimate</a>
         <a href="/#contact">Contact</a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replace hero headline and subheadline to emphasize fast, certified EV charger installs.
- Update all primary CTA links to "Get My Free Estimate" and style them for higher contrast and larger size.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689eb0a48bd8833197b991369d05bc80