### PR TITLE
Add phone conversion tracking

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -16,6 +16,9 @@
     gtag('js', new Date());
 
     gtag('config', 'AW-17428301350');
+    gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
+      'phone_conversion_number': '470-262-2660'
+    });
   </script>
 
   <!-- Analytics -->
@@ -31,6 +34,7 @@
   <section class="contact-section hidden">
     <div class="contact-wrapper">
       <h1>Contact Us</h1>
+      <p class="contact-phone">Call or text: <a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></p>
       <form class="contact-form" action="https://formsubmit.co/integrityevsolutions@gmail.com" method="POST" onsubmit="gtag('event', 'conversion', {'send_to': 'AW-17428301350/ArNACM-3z4MbEKaMu_ZA'});">
         <input type="hidden" name="_next" value="https://www.integrityevsolutions.com/thank-you.html" />
         <input type="hidden" name="_captcha" value="false" />

--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
   gtag('js', new Date());
 
   gtag('config', 'AW-17428301350');
+  gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
+    'phone_conversion_number': '470-262-2660'
+  });
 </script>
 <title>Integrity EV Solutions</title>
 

--- a/thank-you.html
+++ b/thank-you.html
@@ -32,6 +32,9 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'AW-17428301350');
+    gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
+      'phone_conversion_number': '470-262-2660'
+    });
     gtag('event', 'conversion', {
       'send_to': 'AW-17428301350/ArNACM-3z4MbEKaMu_ZA',
       'value': 1.0,


### PR DESCRIPTION
## Summary
- Add Google Ads phone call conversion snippet with dynamic number insertion
- Include tracked phone link on contact page
- Enable site-wide phone number conversion tracking via gtag config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fb1a0f1748331890df0d1afab601b