### PR TITLE
Add privacy policy page with site branding

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,6 +388,7 @@
       <a href="#faqs">FAQs</a>
       <a href="#receive">Get My Free Estimate</a>
       <a href="#contact">Contact</a>
+      <a href="privacy-policy.html">Privacy Policy</a>
     </nav>
     <div class="footer-copy">© 2025 Integrity EV Solutions. All rights reserved.</div>
   </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Privacy Policy | Integrity EV Solutions</title>
+  <meta name="description" content="Privacy policy for Integrity EV Solutions." />
+  <link rel="canonical" href="https://www.integrityevsolutions.com/privacy-policy.html" />
+  <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
+  <link rel="manifest" href="site.webmanifest" />
+  <meta name="robots" content="index, follow" />
+  <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="style.css" />
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17428301350"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'AW-17428301350');
+    gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
+      'phone_conversion_number': '470-262-2660'
+    });
+  </script>
+
+  <!-- Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRSTDB8HTH"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-TRSTDB8HTH');
+  </script>
+</head>
+<body>
+
+  <nav class="site-nav" aria-label="Main Navigation">
+    <div class="container">
+      <div class="brand">
+        <a href="index.html#hero">
+          <img src="logo.png" alt="Integrity EV Solutions logo" />
+        </a>
+        <span>
+          <a href="index.html#hero" class="name">Integrity EV Solutions</a><br>
+          <span class="tagline">Family-Owned • Northern Georgia &amp; Greater Atlanta • <a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></span>
+        </span>
+      </div>
+      <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu">
+      <label for="nav-toggle" class="hamburger" aria-hidden="true">☰</label>
+      <div class="menu">
+        <a href="index.html#hero">Home</a>
+        <a href="index.html#core-values">Core Values</a>
+        <a href="index.html#services">Services</a>
+        <a href="index.html#about">About</a>
+        <a href="index.html#process">Process</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#faqs">FAQs</a>
+        <a href="index.html#receive" class="cta">Get My Free Estimate</a>
+        <a href="index.html#contact">Contact</a>
+      </div>
+    </div>
+  </nav>
+
+  <section class="policy-section hidden">
+    <div class="inner-wrap">
+      <h1>Privacy Policy</h1>
+      <p>At <strong>Integrity EV Solutions LLC</strong>, we respect your privacy. We collect only the personal information you provide, such as your name, phone number, and email address, to respond to your requests for EV charger installations and other electrical services.</p>
+      <p>We <strong>do not share or sell your information</strong> to third parties. Your data is used solely to contact you regarding your service request, provide quotes, and schedule appointments.</p>
+      <p>By submitting your information through our website or Google ads, you agree to this policy. If you have any questions about your information, please contact us at <strong><a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">470-262-2660</a></strong> or via our website.</p>
+    </div>
+  </section>
+
+  <footer class="site-footer">
+    <div class="footer-container">
+      <div class="footer-phone"><a href="tel:4702622660" onclick="gtag('event', 'conversion', {'send_to': 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', 'phone_conversion_number': '470-262-2660'});">📞 470-262-2660</a></div>
+      <nav class="footer-nav" aria-label="Footer Navigation">
+        <a href="index.html#hero">Home</a>
+        <a href="index.html#core-values">Core Values</a>
+        <a href="index.html#services">Services</a>
+        <a href="index.html#about">About</a>
+        <a href="index.html#process">Process</a>
+        <a href="index.html#testimonials">Testimonials</a>
+        <a href="index.html#faqs">FAQs</a>
+        <a href="index.html#receive">Get My Free Estimate</a>
+        <a href="index.html#contact">Contact</a>
+        <a href="privacy-policy.html">Privacy Policy</a>
+      </nav>
+      <div class="footer-copy">© 2025 Integrity EV Solutions. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated `privacy-policy.html` page including existing branding, navigation, and footer
- link to the privacy policy from the site's footer

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689fbab4aa3c8331b5edfa2330982132