### PR TITLE
Consolidate Google tag implementation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -22,18 +22,10 @@
     gtag('js', new Date());
 
     gtag('config', 'AW-17428301350');
+    gtag('config', 'G-TRSTDB8HTH');
     gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
       'phone_conversion_number': '470-262-2660'
     });
-  </script>
-
-  <!-- Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRSTDB8HTH"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-TRSTDB8HTH');
   </script>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   gtag('js', new Date());
 
   gtag('config', 'AW-17428301350');
+  gtag('config', 'G-TRSTDB8HTH');
   gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
     'phone_conversion_number': '470-262-2660'
   });
@@ -41,15 +42,6 @@
 <meta name="twitter:title" content="Integrity EV Solutions | Atlanta EV Charger Installation" />
 <meta name="twitter:description" content="Family-owned, licensed, & insured—your go-to experts for home and business EV charging in Atlanta." />
 <meta name="twitter:image" content="https://www.integrityevsolutions.com/logo.png" />
-
-<!-- Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-TRSTDB8HTH"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-TRSTDB8HTH');
-</script>
 
 <link href="https://fonts.googleapis.com/css2?family=Lato:wght@400;500;700&family=Playfair+Display:wght@700&display=swap" rel="stylesheet"/>
 <link rel="stylesheet" href="style.css"/>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -23,18 +23,10 @@
     gtag('js', new Date());
 
     gtag('config', 'AW-17428301350');
+    gtag('config', 'G-TRSTDB8HTH');
     gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
       'phone_conversion_number': '470-262-2660'
     });
-  </script>
-
-  <!-- Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-TRSTDB8HTH"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-TRSTDB8HTH');
   </script>
 </head>
 <body>

--- a/thank-you.html
+++ b/thank-you.html
@@ -38,6 +38,7 @@
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
     gtag('config', 'AW-17428301350');
+    gtag('config', 'G-TRSTDB8HTH');
     gtag('config', 'AW-17428301350/y-kTCK7tn4MbEKaMu_ZA', {
       'phone_conversion_number': '470-262-2660'
     });


### PR DESCRIPTION
## Summary
- Load Google tag once per page and configure both Ads and Analytics IDs
- Preserve phone call conversion tracking via `phone_conversion_number`
- Include conversion event on thank-you page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fd0a4ec608331a5274ab9250564f9